### PR TITLE
Fix typo in botPlayer log message

### DIFF
--- a/library/botPlayer.js
+++ b/library/botPlayer.js
@@ -31,7 +31,7 @@ var BotPlayer = function(gameId) {
 
 BotPlayer.prototype.start = function() {
     var caller = this;
-    log.log_message('writeFile','botPlayer.log','Initilized ➽ time Stamp '+new Date().toLocaleTimeString());
+    log.log_message('writeFile','botPlayer.log','Initialized ➽ time Stamp '+new Date().toLocaleTimeString());
      var options = {
         hostname: HOST,
         port: PORT,


### PR DESCRIPTION
## Summary
- correct spelling of `Initialized` in botPlayer log

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843ade1bc148328baa26a8fae9b44e7